### PR TITLE
update to angular-datatables 0.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>angular-datatables</artifactId>
-    <version>0.5.3-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <name>angular-datatables</name>
     <description>WebJar for angular-datatables</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.5.2</upstream.version>
+        <upstream.version>0.6.2</upstream.version>
         <upstream.url>http://github.com/l-lin/angular-datatables/archive</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
@@ -77,17 +77,17 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.11.1</version>
+            <version>1.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>datatables</artifactId>
-            <version>1.10.1</version>
+            <version>1.10.16</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>angularjs</artifactId>
-            <version>1.3.0</version>
+            <version>1.6.6</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Update to angular-datatables v0.6.2
Update webjars dependencies: jquery (1.12.4), datatables(1.10.16), angularjs (1.6.6)